### PR TITLE
Use jobName rather than the cloudschedulersource's name.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@
 # Emacs garbage
 *~
 
+# GoLand
+.idea/
+
 # Bazel directories
 bazel-*
 bazel-bin

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -16,12 +16,12 @@ spec:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/secrets/google/key.json
         name: cloudschedulersource-controller
-        image: us.gcr.io/probable-summer-223122/controller
+        image: github.com/vaikas-google/csr/cmd/controller
         args:
         - "-logtostderr=true"
         - "-stderrthreshold=INFO"
         - "-raimage"
-        - "us.gcr.io/probable-summer-223122/receiveadapter"
+        - "github.com/vaikas-google/csr/cmd/receiveadapter"
         volumeMounts:
         - mountPath: /var/secrets/google
           name: google-cloud-key

--- a/pkg/reconciler/cloudschedulersource/cloudschedulersource.go
+++ b/pkg/reconciler/cloudschedulersource/cloudschedulersource.go
@@ -45,7 +45,7 @@ import (
 	"google.golang.org/grpc/codes"
 	gstatus "google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/api/equality"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
 )
@@ -216,7 +216,7 @@ func (c *Reconciler) reconcileCloudSchedulerSource(ctx context.Context, csr *v1a
 	if ksvc.Status.Domain == "" {
 		// TODO: Update status appropriately
 		c.Logger.Infof("No domain configured for service, bailing...")
-		return fmt.Errorf("No domain configured for service")
+		return fmt.Errorf("no domain configured for service")
 	}
 
 	url := fmt.Sprintf("http://%s/", ksvc.Status.Domain)
@@ -273,13 +273,13 @@ func (c *Reconciler) reconcileJob(name string, spec *v1alpha1.CloudSchedulerSour
 
 		existingHttpTarget := existing.GetHttpTarget()
 		if existingHttpTarget == nil {
-			return nil, fmt.Errorf("Missing http target in the existing scheduler proto: %+v", existing)
+			return nil, fmt.Errorf("missing http target in the existing scheduler proto: %+v", existing)
 		}
 
 		updated := createJobProto(jobName, spec, target)
 		updatedHttpTarget := updated.GetHttpTarget()
 		if updatedHttpTarget == nil {
-			return nil, fmt.Errorf("Missing http target in the updated scheduler proto: %+v", updated)
+			return nil, fmt.Errorf("missing http target in the updated scheduler proto: %+v", updated)
 		}
 		if updated.Schedule != existing.Schedule ||
 			updated.TimeZone != existing.TimeZone ||
@@ -307,7 +307,7 @@ func (c *Reconciler) reconcileJob(name string, spec *v1alpha1.CloudSchedulerSour
 
 	req := &schedulerpb.CreateJobRequest{
 		Parent: parent,
-		Job:    createJobProto(name, spec, target),
+		Job:    createJobProto(jobName, spec, target),
 	}
 
 	c.Logger.Infof("Creating job as: %+v", req)
@@ -320,7 +320,7 @@ func (c *Reconciler) reconcileJob(name string, spec *v1alpha1.CloudSchedulerSour
 	return resp, nil
 }
 
-func createJobProto(name string, spec *v1alpha1.CloudSchedulerSourceSpec, target string) *schedulerpb.Job {
+func createJobProto(jobName string, spec *v1alpha1.CloudSchedulerSourceSpec, target string) *schedulerpb.Job {
 	// If no timezone specified, use UTC
 	timezone := "UTC"
 	if spec.TimeZone != "" {
@@ -346,7 +346,7 @@ func createJobProto(name string, spec *v1alpha1.CloudSchedulerSourceSpec, target
 	}
 
 	job := &schedulerpb.Job{
-		Name:     name,
+		Name:     jobName,
 		Schedule: spec.Schedule,
 		TimeZone: timezone,
 		Target:   httpTarget,


### PR DESCRIPTION
Otherwise the following will occur.

cloudschedulersource-system/cloudschedulersource-controller-5457b59dff-s8df7[cloudschedulersource-controller]: {
    "level": "info",
    "ts": 1543525289.7318184,
    "logger": "fallback.controller.cloudschedulersource-controller",
    "caller": "cloudschedulersource/cloudschedulersource.go:313",
    "msg": "Creating job as: parent:\"projects/my-gcp-project/locations/us-central1\" job:<name:\"scheduler-test\" http_target:<uri:\"http://scheduler-test.default.example.org/\" http_method:POST body:\"{test does this work}\" > schedule:\"every 1 mins\" time_zone:\"UTC\" > ",
    "knative.dev/controller": "cloudschedulersource-controller"
}
cloudschedulersource-system/cloudschedulersource-controller-5457b59dff-s8df7[cloudschedulersource-controller]: {
    "level": "info",
    "ts": 1543525289.784251,
    "logger": "fallback.controller.cloudschedulersource-controller",
    "caller": "cloudschedulersource/cloudschedulersource.go:228",
    "msg": "Failed to reconcile Job: rpc error: code = InvalidArgument desc = Job name must be formatted: \"projects/<PROJECT_ID>/locations/<LOCATION_ID>/jobs/<JOB_ID>\".",
    "knative.dev/controller": "cloudschedulersource-controller"
}