### PR TITLE
Clean up things

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -170,7 +170,7 @@
   revision = "5c1d8c8469d1ed34b2aecf4c2305b3a57fff2ee3"
 
 [[projects]]
-  digest = "1:ae93f8409c23ce100d2502d21ea9c8524b9da288e1c2e2fd99c506373a501140"
+  digest = "1:30c67d74a30b65b53cadb2e9797168a911f3c6bcd037e9133f63395045dbfff8"
   name = "github.com/knative/pkg"
   packages = [
     "apis",
@@ -185,7 +185,7 @@
     "signals",
   ]
   pruneopts = "NUT"
-  revision = "3e52d67e3d58f63f43ad61241b00a9974cb03ecd"
+  revision = "f3e33e3b92abb5cc1c63d49b03b56cf813b44676"
 
 [[projects]]
   digest = "1:07e99c5d7a11f4c0d768fef69fb53999ce38b9e359ae039057b7ff10f959bb76"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,7 @@ required = [
 
 [[override]]
   name = "github.com/knative/pkg"
-  revision = "3e52d67e3d58f63f43ad61241b00a9974cb03ecd"
+  revision = "f3e33e3b92abb5cc1c63d49b03b56cf813b44676"
 
 [[override]]
   # Based on the version that google.golang.org/genproto depends on at HEAD.

--- a/config/cloudschedulersource.yaml
+++ b/config/cloudschedulersource.yaml
@@ -3,6 +3,8 @@ kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: cloudschedulersources.sources.aikas.org
+  labels:
+    eventing.knative.dev/source: "true"
 spec:
   group: sources.aikas.org
   version: v1alpha1
@@ -16,3 +18,43 @@ spec:
     plural: cloudschedulersources
     singular: cloudschedulersource
     kind: CloudSchedulerSource
+    shortNames:
+    - csr
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            serviceAccountName:
+              type: string
+              description: "Service Account to run Receive Adapter as. If omitted, uses 'default'."
+            googleCloudProject:
+              type: string
+              description: "Google Cloud Project ID to create the scheduler job in."
+            location:
+              type: string
+              description: "Google Cloud Platform region to create the scheduler job in. For example: us-central1."
+            schedule:
+              type: string
+              description: "Schedule in cron format. For example: '* * * * *' (once a minute), or human readable: 'every 1 mins'"
+            timezone:
+              type: string
+              description: "Optional timezone of the schedule. If omitted, uses UTC."
+            httpMethod:
+              type: string
+              description: "Optional HTTP method to use when delivering the event. If omitted, uses POST"
+            body:
+              type: string
+              description: "Optional body to send in the event"
+            sink:
+              type: object
+          required:
+          - googleCloudProject
+          - location
+          - schedule

--- a/pkg/apis/cloudschedulersource/v1alpha1/types.go
+++ b/pkg/apis/cloudschedulersource/v1alpha1/types.go
@@ -41,7 +41,7 @@ type CloudSchedulerSourceSpec struct {
 	// ServiceAccountName holds the name of the Kubernetes service account
 	// as which the underlying K8s resources should be run. If unspecified
 	// this will default to the "default" service account for the namespace
-	// in which the GitHubSource exists.
+	// in which the CloudSchedulerSource exists.
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 

--- a/release.yaml
+++ b/release.yaml
@@ -7,6 +7,8 @@ metadata:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+    eventing.knative.dev/source: "true"
   name: cloudschedulersources.sources.aikas.org
 spec:
   group: sources.aikas.org
@@ -18,8 +20,52 @@ spec:
     - sources
     kind: CloudSchedulerSource
     plural: cloudschedulersources
+    shortNames:
+    - csr
     singular: cloudschedulersource
   scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            body:
+              description: Optional body to send in the event
+              type: string
+            googleCloudProject:
+              description: Google Cloud Project ID to create the scheduler job in.
+              type: string
+            httpMethod:
+              description: Optional HTTP method to use when delivering the event.
+                If omitted, uses POST
+              type: string
+            location:
+              description: 'Google Cloud Platform region to create the scheduler job
+                in. For example: us-central1.'
+              type: string
+            schedule:
+              description: 'Schedule in cron format. For example: ''* * * * *'' (once
+                a minute), or human readable: ''every 1 mins'''
+              type: string
+            serviceAccountName:
+              description: Service Account to run Receive Adapter as. If omitted,
+                uses 'default'.
+              type: string
+            sink:
+              type: object
+            timezone:
+              description: Optional timezone of the schedule. If omitted, uses UTC.
+              type: string
+          required:
+          - googleCloudProject
+          - location
+          - schedule
   version: v1alpha1
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -52,11 +98,11 @@ spec:
         - -logtostderr=true
         - -stderrthreshold=INFO
         - -raimage
-        - us.gcr.io/probable-summer-223122/receiveadapter-ed34e5d5c6278be2ee9b98fdb9ad4d9d@sha256:5db6ef89e1dc9a37772baf7080b3ac7444391483bf48b09738e4fe207eee7eb2
+        - us.gcr.io/probable-summer-223122/receiveadapter-ed34e5d5c6278be2ee9b98fdb9ad4d9d@sha256:3cfdb84bcfdc38bd03177c4933d36242969c77447a63d147dcda4f436eaea498
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/secrets/google/key.json
-        image: us.gcr.io/probable-summer-223122/controller-870d05653c81134f2e0c38c2ba82aabd@sha256:943789c2ffd756d2fa61d04e0ecd0f2efe4c97591d11792e66ce5dd5f60b66e4
+        image: us.gcr.io/probable-summer-223122/controller-870d05653c81134f2e0c38c2ba82aabd@sha256:3e1ac6864f92d15a0dc774d8d18bac278174fc3d01de83f214239300d6a76de2
         name: cloudschedulersource-controller
         volumeMounts:
         - mountPath: /var/secrets/google

--- a/service.yaml
+++ b/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
@@ -9,4 +10,4 @@ spec:
       revisionTemplate:
         spec:
           container:
-            image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/message_dumper
+            image: us.gcr.io/probable-summer-223122/eventdumper-833f921e52f6ce76eb11f89bbfcea1df@sha256:7edb9fc190dcf350f4c49c48d3ff2bf71de836ff3dc32b1d5082fd13f90edee3

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/addressable_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/addressable_types.go
@@ -37,7 +37,6 @@ type Addressable struct {
 	Hostname string `json:"hostname,omitempty"`
 }
 
-
 // Addressable is an Implementable "duck type".
 var _ duck.Implementable = (*Addressable)(nil)
 

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/generational_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/generational_types.go
@@ -27,7 +27,6 @@ import (
 // Generation is the schema for the generational portion of the payload
 type Generation int64
 
-
 // Generation is an Implementable "duck type".
 var _ duck.Implementable = (*Generation)(nil)
 

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/legacy_targetable_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/legacy_targetable_types.go
@@ -41,7 +41,6 @@ type LegacyTargetable struct {
 	DomainInternal string `json:"domainInternal,omitempty"`
 }
 
-
 // LegacyTargetable is an Implementable "duck type".
 var _ duck.Implementable = (*LegacyTargetable)(nil)
 

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/retired_targetable_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/retired_targetable_types.go
@@ -37,7 +37,6 @@ type Targetable struct {
 	DomainInternal string `json:"domainInternal,omitempty"`
 }
 
-
 // Targetable is an Implementable "duck type".
 var _ duck.Implementable = (*Targetable)(nil)
 

--- a/vendor/github.com/knative/pkg/apis/field_error.go
+++ b/vendor/github.com/knative/pkg/apis/field_error.go
@@ -133,34 +133,36 @@ func (fe *FieldError) isEmpty() bool {
 	return fe.Message == "" && fe.Details == "" && len(fe.errors) == 0 && len(fe.Paths) == 0
 }
 
-func (fe *FieldError) getNormalizedErrors() []FieldError {
-	// in case we call getNormalizedErrors on a nil object, return just an empty
+// normalized returns a flattened copy of all the errors.
+func (fe *FieldError) normalized() []*FieldError {
+	// In case we call normalized on a nil object, return just an empty
 	// list. This can happen when .Error() is called on a nil object.
 	if fe == nil {
-		return []FieldError(nil)
+		return []*FieldError(nil)
 	}
-	var errors []FieldError
-	// if this FieldError is a leaf,
+
+	// Allocate errors with at least as many objects as we'll get on the first pass.
+	errors := make([]*FieldError, 0, len(fe.errors)+1)
+	// If this FieldError is a leaf, add it.
 	if fe.Message != "" {
-		err := FieldError{
+		errors = append(errors, &FieldError{
 			Message: fe.Message,
 			Paths:   fe.Paths,
 			Details: fe.Details,
-		}
-		errors = append(errors, err)
+		})
 	}
-	// and then collect all other errors recursively.
+	// And then collect all other errors recursively.
 	for _, e := range fe.errors {
-		errors = append(errors, e.getNormalizedErrors()...)
+		errors = append(errors, e.normalized()...)
 	}
 	return errors
 }
 
 // Error implements error
 func (fe *FieldError) Error() string {
-	var errs []string
 	// Get the list of errors as a flat merged list.
-	normedErrors := merge(fe.getNormalizedErrors())
+	normedErrors := merge(fe.normalized())
+	errs := make([]string, 0, len(normedErrors))
 	for _, e := range normedErrors {
 		if e.Details == "" {
 			errs = append(errs, fmt.Sprintf("%v: %v", e.Message, strings.Join(e.Paths, ", ")))
@@ -198,7 +200,7 @@ func flatten(path []string) string {
 			if p == CurrentField {
 				continue
 			} else if len(newPath) > 0 && isIndex(p) {
-				newPath[len(newPath)-1] = fmt.Sprintf("%s%s", newPath[len(newPath)-1], p)
+				newPath[len(newPath)-1] += p
 			} else {
 				newPath = append(newPath, p)
 			}
@@ -232,22 +234,21 @@ func containsString(slice []string, s string) bool {
 }
 
 // merge takes in a flat list of FieldErrors and returns back a merged list of
-// FiledErrors. FieldErrors have their Paths combined (and de-duped) if their
+// FieldErrors. FieldErrors have their Paths combined (and de-duped) if their
 // Message and Details are the same. Merge will not inspect FieldError.errors.
 // Merge will also sort the .Path slice, and the errors slice before returning.
-func merge(errs []FieldError) []FieldError {
+func merge(errs []*FieldError) []*FieldError {
 	// make a map big enough for all the errors.
-	m := make(map[string]FieldError, len(errs))
+	m := make(map[string]*FieldError, len(errs))
 
 	// Convert errs to a map where the key is <message>-<details> and the value
 	// is the error. If an error already exists in the map with the same key,
 	// then the paths will be merged.
 	for _, e := range errs {
-		k := key(&e)
+		k := key(e)
 		if v, ok := m[k]; ok {
 			// Found a match, merge the keys.
 			v.Paths = mergePaths(v.Paths, e.Paths)
-			m[k] = v
 		} else {
 			// Does not exist in the map, save the error.
 			m[k] = e
@@ -255,7 +256,7 @@ func merge(errs []FieldError) []FieldError {
 	}
 
 	// Take the map made previously and flatten it back out again.
-	newErrs := make([]FieldError, 0, len(m))
+	newErrs := make([]*FieldError, 0, len(m))
 	for _, v := range m {
 		// While we have access to the merged paths, sort them too.
 		sort.Slice(v.Paths, func(i, j int) bool { return v.Paths[i] < v.Paths[j] })
@@ -336,7 +337,7 @@ func ErrInvalidKeyName(value, fieldPath string, details ...string) *FieldError {
 	}
 }
 
-// ErrOutOFBoundsValue constructs a FieldError for a field that has received an
+// ErrOutOfBoundsValue constructs a FieldError for a field that has received an
 // out of bound value.
 func ErrOutOfBoundsValue(value, lower, upper, fieldPath string) *FieldError {
 	return &FieldError{

--- a/vendor/github.com/knative/pkg/cloudevents/handler.go
+++ b/vendor/github.com/knative/pkg/cloudevents/handler.go
@@ -24,8 +24,10 @@ import (
 	"log"
 	"net/http"
 	"reflect"
+	"strings"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/google/uuid"
 )
 
 type handler struct {
@@ -45,7 +47,7 @@ type errAndHandler interface {
 
 const (
 	inParamUsage  = "Expected a function taking either no parameters, a context.Context, or (context.Context, any)"
-	outParamUsage = "Expected a function returning either nothing, an error, or (any, error)"
+	outParamUsage = "Expected a function returning either nothing, an error, (any, error), or (any, EventContext, error)"
 )
 
 var (
@@ -57,8 +59,9 @@ var (
 	// it leaves this stack frame. The workaround is to pass a pointer to an interface and then
 	// get the type of its reference.
 	// For example, see: https://play.golang.org/p/_dxLvdkvqvg
-	contextType = reflect.TypeOf((*context.Context)(nil)).Elem()
-	errorType   = reflect.TypeOf((*error)(nil)).Elem()
+	contextType      = reflect.TypeOf((*context.Context)(nil)).Elem()
+	errorType        = reflect.TypeOf((*error)(nil)).Elem()
+	eventContextType = reflect.TypeOf((*EventContext)(nil)).Elem()
 )
 
 // Verifies that the inputs to a function have a valid signature; panics otherwise.
@@ -85,6 +88,12 @@ func validateInParamSignature(fnType reflect.Type) error {
 // (), (error), (any, error)
 func validateOutParamSignature(fnType reflect.Type) error {
 	switch fnType.NumOut() {
+	case 3:
+		contextType := fnType.Out(1)
+		if !contextType.ConvertibleTo(eventContextType) {
+			return fmt.Errorf("%s; cannot convert return type 1 from %s to EventContext", outParamUsage, contextType)
+		}
+		fallthrough
 	case 2:
 		fallthrough
 	case 1:
@@ -135,37 +144,58 @@ func allocate(t reflect.Type) (asPtr interface{}, asValue reflect.Value) {
 	return
 }
 
-func unwrapReturnValues(res []reflect.Value) (interface{}, error) {
+func unwrapReturnValues(res []reflect.Value) (interface{}, *EventContext, error) {
 	switch len(res) {
 	case 0:
-		return nil, nil
+		return nil, nil, nil
 	case 1:
 		if res[0].IsNil() {
-			return nil, nil
+			return nil, nil, nil
 		}
 		// Should be a safe cast due to assertEventHandler()
-		return nil, res[0].Interface().(error)
+		return nil, nil, res[0].Interface().(error)
 	case 2:
 		if res[1].IsNil() {
-			return res[0].Interface(), nil
+			return res[0].Interface(), nil, nil
 		}
 		// Should be a safe cast due to assertEventHandler()
-		return nil, res[1].Interface().(error)
+		return nil, nil, res[1].Interface().(error)
+	case 3:
+		if res[2].IsNil() {
+			ec := res[1].Interface().(EventContext)
+			return res[0].Interface(), &ec, nil
+		}
+		return nil, nil, res[2].Interface().(error)
 	default:
 		// Should never happen due to assertEventHandler()
-		panic("Cannot unmarshal more than 2 return values")
+		panic("Cannot unmarshal more than 3 return values")
 	}
 }
 
 // Accepts the results from a handler functions and translates them to an HTTP response
-func respondHTTP(outparams []reflect.Value, w http.ResponseWriter) {
-	res, err := unwrapReturnValues(outparams)
+func respondHTTP(outparams []reflect.Value, fn reflect.Value, w http.ResponseWriter) {
+	res, ec, err := unwrapReturnValues(outparams)
 
 	if err != nil {
 		log.Print("Failed to handle event: ", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(`Internal server error`))
 		return
+	}
+	if ec == nil {
+		eventType := strings.Replace(fn.Type().PkgPath(), "/", ".", -1)
+		if eventType != "" {
+			eventType += "."
+		}
+		eventType += fn.Type().Name()
+		if eventType == "" {
+			eventType = "dev.knative.pkg.cloudevents.unknown"
+		}
+		ec = &EventContext{
+			EventID:   uuid.New().String(),
+			EventType: eventType,
+			Source:    "unknown", // TODO: anything useful here, maybe incoming Host header?
+		}
 	}
 
 	if res != nil {
@@ -174,9 +204,16 @@ func respondHTTP(outparams []reflect.Value, w http.ResponseWriter) {
 			log.Printf("Failed to marshal return value %+v: %s", res, err)
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(`Internal server error`))
-		} else {
-			w.Write(json)
+			return
 		}
+		err = Binary.ToHeaders(ec, w.Header())
+		if err != nil {
+			log.Printf("Failed to marshal headers for response: %+v: %s", ec, err)
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`Internal server error`))
+			return
+		}
+		w.Write(json)
 		return
 	}
 
@@ -190,12 +227,15 @@ func respondHTTP(outparams []reflect.Value, w http.ResponseWriter) {
 // * func()
 // * func() error
 // * func() (anything, error)
+// * func() (anything, EventContext, error)
 // * func(context.Context)
 // * func(context.Context) error
 // * func(context.Context) (anything, error)
+// * func(context.Context) (anything, EventContext, error)
 // * func(context.Context, anything)
 // * func(context.Context, anything) error
 // * func(context.Context, anything) (anything, error)
+// * func(context.Context, anything) (anything, EventContext, error)
 //
 // CloudEvent contexts are available from the context.Context parameter
 // CloudEvent data will be deserialized into the "anything" parameter.
@@ -205,7 +245,8 @@ func respondHTTP(outparams []reflect.Value, w http.ResponseWriter) {
 // HTTP responses are generated based on the return value of fn:
 // * any error return value will cause a StatusInternalServerError response
 // * a function with no return type or a function returning nil will cause a StatusNoContent response
-// * a function that returns a value will cause a StatusOK and render the response as JSON
+// * a function that returns a value will cause a StatusOK and render the response as JSON,
+//   with headers from an EventContext, if appropriate
 func Handler(fn interface{}) http.Handler {
 	fnType := reflect.TypeOf(fn)
 	err := validateFunction(fnType)
@@ -248,7 +289,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res := h.fnValue.Call(args)
-	respondHTTP(res, w)
+	respondHTTP(res, h.fnValue, w)
 }
 
 func (h failedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -349,5 +390,5 @@ func (m Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res := h.fnValue.Call(args)
-	respondHTTP(res, w)
+	respondHTTP(res, h.fnValue, w)
 }

--- a/vendor/github.com/knative/pkg/controller/controller.go
+++ b/vendor/github.com/knative/pkg/controller/controller.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
@@ -136,12 +135,11 @@ func (c *Impl) EnqueueControllerOf(obj interface{}) {
 	}
 }
 
-// EnqueueLabelOf returns with an Enqueue func that takes a resource,
-// identifies its controller resource through given namespace and name labels,
-// converts it into a namespace/name string, and passes that to EnqueueKey.
-// Callers should pass in an empty string as namespace label key for obj
-// whose controller is of cluster-scoped resource.
-func (c *Impl) EnqueueLabelOf(namespaceLabel, nameLabel string) func(obj interface{}) {
+// EnqueueLabelOfNamespaceScopedResource returns with an Enqueue func that
+// takes a resource, identifies its controller resource through given namespace
+// and name labels, converts it into a namespace/name string, and passes that
+// to EnqueueKey. The controller resource must be of namespace-scoped.
+func (c *Impl) EnqueueLabelOfNamespaceScopedResource(namespaceLabel, nameLabel string) func(obj interface{}) {
 	return func(obj interface{}) {
 		object, err := kmeta.DeletionHandlingAccessor(obj)
 		if err != nil {
@@ -152,7 +150,7 @@ func (c *Impl) EnqueueLabelOf(namespaceLabel, nameLabel string) func(obj interfa
 		labels := object.GetLabels()
 		controllerKey, ok := labels[nameLabel]
 		if !ok {
-			c.logger.Infof("Object %s/%s does not have a referring name label %s",
+			c.logger.Debugf("Object %s/%s does not have a referring name label %s",
 				object.GetNamespace(), object.GetName(), nameLabel)
 			return
 		}
@@ -160,12 +158,40 @@ func (c *Impl) EnqueueLabelOf(namespaceLabel, nameLabel string) func(obj interfa
 		if namespaceLabel != "" {
 			controllerNamespace, ok := labels[namespaceLabel]
 			if !ok {
-				c.logger.Infof("Object %s/%s does not have a referring namespace label %s",
+				c.logger.Debugf("Object %s/%s does not have a referring namespace label %s",
 					object.GetNamespace(), object.GetName(), namespaceLabel)
 				return
 			}
 
-			controllerKey = fmt.Sprintf("%s/%s", controllerNamespace, controllerKey)
+			c.EnqueueKey(fmt.Sprintf("%s/%s", controllerNamespace, controllerKey))
+			return
+		}
+
+		// Pass through namespace of the object itself if no namespace label specified.
+		// This is for the scenario that object and the parent resource are of same namespace,
+		// e.g. to enqueue the revision of an endpoint.
+		c.EnqueueKey(fmt.Sprintf("%s/%s", object.GetNamespace(), controllerKey))
+	}
+}
+
+// EnqueueLabelOfClusterScopedResource returns with an Enqueue func
+// that takes a resource, identifies its controller resource through
+// given name label, and passes it to EnqueueKey.
+// The controller resource must be of cluster-scoped.
+func (c *Impl) EnqueueLabelOfClusterScopedResource(nameLabel string) func(obj interface{}) {
+	return func(obj interface{}) {
+		object, err := kmeta.DeletionHandlingAccessor(obj)
+		if err != nil {
+			c.logger.Error(err)
+			return
+		}
+
+		labels := object.GetLabels()
+		controllerKey, ok := labels[nameLabel]
+		if !ok {
+			c.logger.Debugf("Object %s/%s does not have a referring name label %s",
+				object.GetNamespace(), object.GetName(), nameLabel)
+			return
 		}
 
 		c.EnqueueKey(controllerKey)
@@ -188,10 +214,10 @@ func (c *Impl) Run(threadiness int, stopCh <-chan struct{}) error {
 	logger := c.logger
 	logger.Info("Starting controller and workers")
 	for i := 0; i < threadiness; i++ {
-		go wait.Until(func() {
+		go func() {
 			for c.processNextWorkItem() {
 			}
-		}, time.Second, stopCh)
+		}()
 	}
 
 	logger.Info("Started workers")
@@ -208,74 +234,52 @@ func (c *Impl) processNextWorkItem() bool {
 	if shutdown {
 		return false
 	}
+	key := obj.(string)
 
-	// We wrap this block in a func so we can defer c.base.WorkQueue.Done.
-	err := func(obj interface{}) error {
-		startTime := time.Now()
-		// Send the metrics for the current queue depth
-		c.statsReporter.ReportQueueDepth(int64(c.WorkQueue.Len()))
+	startTime := time.Now()
+	// Send the metrics for the current queue depth
+	c.statsReporter.ReportQueueDepth(int64(c.WorkQueue.Len()))
 
-		// We call Done here so the workqueue knows we have finished
-		// processing this item. We also must remember to call Forget if we
-		// do not want this work item being re-queued. For example, we do
-		// not call Forget if a transient error occurs, instead the item is
-		// put back on the workqueue and attempted again after a back-off
-		// period.
-		defer c.WorkQueue.Done(obj)
+	// We call Done here so the workqueue knows we have finished
+	// processing this item. We also must remember to call Forget if
+	// reconcile succeeds. If a transient error occurs, we do not call
+	// Forget and put the item back to the queue with an increased
+	// delay.
+	defer c.WorkQueue.Done(key)
 
-		// We expect strings to come off the workqueue. These are of the
-		// form namespace/name. We do this as the delayed nature of the
-		// workqueue means the items in the informer cache may actually be
-		// more up to date that when the item was initially put onto the
-		// workqueue.
-		key, ok := obj.(string)
-		if !ok {
-			// As the item in the workqueue is actually invalid, we call
-			// Forget here else we'd go into a loop of attempting to
-			// process a work item that is invalid.
-			c.WorkQueue.Forget(obj)
-			c.logger.Errorf("expected string in workqueue but got %#v", obj)
-			c.statsReporter.ReportReconcile(time.Now().Sub(startTime), "[InvalidKeyType]", falseString)
-			return nil
+	var err error
+	defer func() {
+		status := trueString
+		if err != nil {
+			status = falseString
 		}
+		c.statsReporter.ReportReconcile(time.Now().Sub(startTime), key, status)
+	}()
 
-		var err error
-		defer func() {
-			status := trueString
-			if err != nil {
-				status = falseString
-			}
-			c.statsReporter.ReportReconcile(time.Now().Sub(startTime), key, status)
-		}()
+	// Embed the key into the logger and attach that to the context we pass
+	// to the Reconciler.
+	logger := c.logger.With(zap.String(logkey.Key, key))
+	ctx := logging.WithLogger(context.TODO(), logger)
 
-		// Embed the key into the logger and attach that to the context we pass
-		// to the Reconciler.
-		logger := c.logger.With(zap.String(logkey.Key, key))
-		ctx := logging.WithLogger(context.TODO(), logger)
-
-		// Run Reconcile, passing it the namespace/name string of the
-		// resource to be synced.
-		if err = c.Reconciler.Reconcile(ctx, key); err != nil {
-			c.handleErr(err, key)
-			return fmt.Errorf("error syncing %q: %v", key, err)
-		}
-
-		// Finally, if no error occurs we Forget this item so it does not
-		// get queued again until another change happens.
-		c.WorkQueue.Forget(obj)
-		c.logger.Infof("Successfully synced %q", key)
-		return nil
-	}(obj)
-
-	if err != nil {
-		c.logger.Error(zap.Error(err))
+	// Run Reconcile, passing it the namespace/name string of the
+	// resource to be synced.
+	if err = c.Reconciler.Reconcile(ctx, key); err != nil {
+		c.handleErr(err, key)
+		logger.Errorf("Reconcile failed. Time taken: %v.", time.Now().Sub(startTime))
 		return true
 	}
+
+	// Finally, if no error occurs we Forget this item so it does not
+	// have any delay when another change happens.
+	c.WorkQueue.Forget(key)
+	logger.Infof("Reconcile succeeded. Time taken: %v.", time.Now().Sub(startTime))
 
 	return true
 }
 
-func (c *Impl) handleErr(err error, key interface{}) {
+func (c *Impl) handleErr(err error, key string) {
+	c.logger.Error(zap.Error(err))
+
 	// Re-queue the key if it's an transient error.
 	if !IsPermanentError(err) {
 		c.WorkQueue.AddRateLimited(key)

--- a/vendor/github.com/knative/pkg/controller/stats_reporter.go
+++ b/vendor/github.com/knative/pkg/controller/stats_reporter.go
@@ -123,7 +123,7 @@ func (r *reporter) ReportReconcile(duration time.Duration, key, success string) 
 	}
 
 	stats.Record(ctx, reconcileCountStat.M(1))
-	stats.Record(ctx, reconcileLatencyStat.M(int64(duration)))
+	stats.Record(ctx, reconcileLatencyStat.M(int64(duration/time.Millisecond)))
 	return nil
 }
 


### PR DESCRIPTION
 * receive adapter now uses the body as string so things show up as NON-base64 encoded bodies
 * add Event Dumper, which shows the Cloud Event received as decoded instead of the old message dumper that showed the wire format.
 * clean up the README
